### PR TITLE
Clarify function used in upper-case-first tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 var assert = require('assert')
-var lowerCase = require('./')
+var upperCaseFirst = require('./')
 
 describe('upper case first', function () {
   it('should upper case the first character a string', function () {
-    assert.equal(lowerCase(null), '')
-    assert.equal(lowerCase('test'), 'Test')
-    assert.equal(lowerCase('TEST'), 'TEST')
+    assert.equal(upperCaseFirst(null), '')
+    assert.equal(upperCaseFirst('test'), 'Test')
+    assert.equal(upperCaseFirst('TEST'), 'TEST')
   })
 })


### PR DESCRIPTION
Clarifies what function is being tested. This threw me off for a second when I was looking at it.